### PR TITLE
Update requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,9 @@
 pre-commit
 
 # static analysis
-black==21.9b0
-flake8==4.0.1
-flake8-black==0.2.3
-flake8-print==4.0.0
+black==22.8.0
+flake8==5.0.4
+flake8-print==5.0.0
 flake8-todo==0.7
 
 # pumpkin.py tools


### PR DESCRIPTION
Fixes:

```
Run black . --diff
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.[8](https://github.com/pumpkin-py/pumpkin-vote/actions/runs/4640227290/jobs/8211944084#step:6:9).16/x64/bin/black", line 8, in <module>
    sys.exit(patched_main())
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/black/__init__.py", line [12](https://github.com/pumpkin-py/pumpkin-vote/actions/runs/4640227290/jobs/8211944084#step:6:13)82, in patched_main
    patch_click()
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/black/__init__.py", line 1268, in patch_click
    from click import _unicodefun  # type: ignore
ImportError: cannot import name '_unicodefun' from 'click' (/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/click/__init__.py)
Error: Process completed with exit code 1.
```